### PR TITLE
fix bin build. fix bikeshed error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,6 @@
   :jvm-opts ["-server"]
 
   :bin {:name "manetu-data-loader"
-        :bin-path "target"
         :bootclasspath false}
 
   :eastwood {:add-linters [:unused-namespaces]

--- a/src/manetu/data_loader/main.clj
+++ b/src/manetu/data_loader/main.clj
@@ -95,7 +95,8 @@
 
 (defn -app
   [& args]
-  (let [{{:keys [help log-level url token] :as options} :options :keys [arguments errors summary]} (parse-opts args options)]
+  (let [{{:keys [help log-level url token] :as options} :options :keys
+         [arguments errors summary]} (parse-opts args options)]
     (cond
 
       help


### PR DESCRIPTION
Remove the bin:binpath option from the project spec. This was causing lein-bin to write an empty binary to target/.
Shorten a line in src/manetu/dataloader/main.clj to fit in the 120 char bikeshed option (rather than just keep bumping the option).

